### PR TITLE
Parse HandBrakeCLI JSON output (Fixes #234)

### DIFF
--- a/bin/convert-video
+++ b/bin/convert-video
@@ -62,7 +62,7 @@ HERE
 
       opts.on '--ac3-encoder ARG' do |arg|
         @ac3_encoder = case arg
-        when 'ac3', 'eac3'
+        when /ac3/i, /eac3/i
           arg
         else
           fail UsageError, "invalid AC-3 audio encoder: #{arg}"
@@ -87,7 +87,6 @@ HERE
       Console.debug media.info.inspect
       output = resolve_output(media)
       fail "no compatible video track: #{arg}" unless media.info[:h264] or media.info[:hevc]
-      fail "no video stream: #{arg}" unless media.info.has_key? :stream
 
       if media.info[:mkv]
         convert_to_mp4(media, output)
@@ -130,7 +129,7 @@ HERE
         if @double and media.info[:audio][1][:channels] > 2.0
           if  track_order.size > 1 and
               media.info[:audio][1][:language] == media.info[:audio][2][:language] and
-              media.info[:audio][2][:format] =~ /^AAC/ and
+              media.info[:audio][2][:format] =~ /^AAC/i and
               media.info[:audio][2][:channels] <= 2.0
             first = track_order[0]
             track_order[0] = track_order[1]
@@ -161,7 +160,7 @@ HERE
               "-b:a:#{stream}", '640k'
             ])
           elsif media.info[:audio][track][:channels] <= 2.0 and
-                not media.info[:audio][track][:format] =~ /^AAC/ and
+                not media.info[:audio][track][:format] =~ /^AAC/i and
                 not ac3_format?(media.info[:audio][track][:format])
             copy_options.concat([
               "-ac:a:#{stream}", '2',
@@ -188,10 +187,10 @@ HERE
           break unless media.info[:subtitle][track].has_key? :stream
 
           subtitle_encoder = case media.info[:subtitle][track][:format]
-          when 'Text'
+          when /Text/i
             'mov_text'
-          when 'Bitmap'
-            if media.info[:subtitle][track][:encoding] == 'VOBSUB'
+          when /Bitmap/i
+            if media.info[:subtitle][track][:encoding] =~ /VOBSUB/i
               'copy'
             else
               nil
@@ -249,8 +248,8 @@ HERE
     end
 
     def ac3_format?(track_format)
-      if  (@ac3_encoder == 'ac3'  and track_format == 'AC3') or
-          (@ac3_encoder == 'eac3' and track_format =~ /^(?:E-)?AC3$/)
+      if  (@ac3_encoder == 'ac3'  and track_format =~ /AC3/i) or
+          (@ac3_encoder == 'eac3' and track_format =~ /^(?:E-)?AC3$/i)
         true
       else
         false
@@ -294,7 +293,7 @@ HERE
         if  @double and
             track_order.size > 1 and
             media.info[:audio][1][:language] == media.info[:audio][2][:language] and
-            media.info[:audio][1][:format] =~ /^AAC/ and
+            media.info[:audio][1][:format] =~ /^AAC/i and
             media.info[:audio][1][:channels] <= 2.0 and
             media.info[:audio][2][:channels] > 2.0
           first = track_order[0]
@@ -323,10 +322,10 @@ HERE
 
         track_order.each do |track|
           subtitle_encoder = case media.info[:subtitle][track][:format]
-          when 'Text'
+          when /Text/i
             'text'
-          when 'Bitmap'
-            if media.info[:subtitle][track][:encoding] == 'VOBSUB'
+          when /Bitmap/i
+            if media.info[:subtitle][track][:encoding] =~ /VOBSUB/i
               'dvdsub'
             else
               nil

--- a/bin/transcode-video
+++ b/bin/transcode-video
@@ -1145,10 +1145,10 @@ HERE
 
         if copy or
             (@surround_format == 'ac3' and
-            ((@ac3_encoder == 'ac3' and info[:format] == 'AC3') or
-            (@ac3_encoder == 'eac3' and info[:format] =~ /^(?:E-)?AC3$/)) and
+            ((@ac3_encoder == 'ac3' and info[:format] =~ /AC3/i) or
+            (@ac3_encoder == 'eac3' and info[:format] =~ /^(?:E-)?AC3$/i)) and
             bitrate <= @pass_ac3_bitrate) or
-            (@surround_format == 'aac' and info[:format] =~ /^AAC/)
+            (@surround_format == 'aac' and info[:format] =~ /^AAC/i)
           encoders << 'copy'
           bitrates << ''
           mixdowns << ''
@@ -1174,9 +1174,9 @@ HERE
       add_stereo = ->(info, copy) do
         if copy or
             (info[:channels] <= 2.0 and
-              ((@stereo_format == 'aac' and info[:format] =~ /^AAC/) or
-              (((@ac3_encoder == 'ac3' and info[:format] == 'AC3') or
-              (@ac3_encoder == 'eac3' and info[:format] =~ /^(?:E-)?AC3$/)) and
+              ((@stereo_format == 'aac' and info[:format] =~ /^AAC/i) or
+              (((@ac3_encoder == 'ac3' and info[:format] =~ /AC3/i) or
+              (@ac3_encoder == 'eac3' and info[:format] =~ /^(?:E-)?AC3$/i)) and
               (@keep_ac3_stereo or @stereo_format == 'ac3'))))
           encoders << 'copy'
           bitrates << ''

--- a/lib/video_transcoding/media.rb
+++ b/lib/video_transcoding/media.rb
@@ -225,7 +225,7 @@ module VideoTranscoding
           @summary = io.readlines.select do |line|
             # HandBrakeCLI gives a summary where each line begins with
             # a '+' character.
-            fixup_hb_output(line).match(/^\s*\+ (?!(autocrop|support))/)
+            Media.fixup_hb_output(line).match(/^\s*\+ (?!(autocrop|support))/)
           end.join('')
         end
       end

--- a/lib/video_transcoding/version.rb
+++ b/lib/video_transcoding/version.rb
@@ -5,5 +5,5 @@
 #
 
 module VideoTranscoding
-  VERSION = '0.25.3'
+  VERSION = '0.26.0'
 end


### PR DESCRIPTION
Uses the `HandBrakeCLI --json` option to get media info. 

Tested with
- ntodd/video-transcoding Docker image (ruby 2.4.0p0, HandBrake 1.1.2, ffmpeg version 4.1, Ubuntu 16.04)
- ruby 2.7.0p0, HandBrake 1.3.3, ffmpeg version 4.2.4-1ubuntu0.1, Ubuntu 20.04

I ran `transcode-video --dry-run` on a bunch of DVD directory rips and a couple of .mkv and .mp4 files with no options and compared the output between video_transcoding-0.25.3 and video_transcoding-0.26.0 (this PR). The output for all of those was the same. When I added `--crop detect --add-audio "spa" --add-subtitle "eng,spa"`, the only difference was that subtitle tracks were correctly added. My video library is very limited, however, and I didn't play with any of the other options.

`convert-video` ~~doesn't always select the correct streams (the stream IDs aren't available in the HandBrake JSON output).~~ Should now select the streams correctly, though it will only get the first video stream (which I think matches the old behavior, and is probably the most common use case).
`detect-crop` seems unaffected. 

TODOs:
- ~~Add stream IDs to media.info. They are not available in the JSON output, so they need to be found elsewhere.~~
- Needs a lot of further testing.